### PR TITLE
Fix armor disappearing when player is refreshed

### DIFF
--- a/src/main/java/org/kitteh/tag/TagAPI.java
+++ b/src/main/java/org/kitteh/tag/TagAPI.java
@@ -136,10 +136,10 @@ public class TagAPI extends JavaPlugin {
             otherGuyC.getHandle().netServerHandler.sendPacket(new Packet29DestroyEntity(id));
             otherGuyC.getHandle().netServerHandler.sendPacket(new Packet20NamedEntitySpawn(human));
             if(player.getItemInHand() != null) otherGuyC.getHandle().netServerHandler.sendPacket(new Packet5EntityEquipment(id, 0, ((CraftItemStack)player.getItemInHand()).getHandle()));
-            if(player.getInventory().getHelmet() != null) otherGuyC.getHandle().netServerHandler.sendPacket(new Packet5EntityEquipment(id, 1, ((CraftItemStack)player.getInventory().getHelmet()).getHandle()));
-            if(player.getInventory().getChestplate() != null) otherGuyC.getHandle().netServerHandler.sendPacket(new Packet5EntityEquipment(id, 2, ((CraftItemStack)player.getInventory().getChestplate()).getHandle()));
-            if(player.getInventory().getLeggings() != null) otherGuyC.getHandle().netServerHandler.sendPacket(new Packet5EntityEquipment(id, 3, ((CraftItemStack)player.getInventory().getLeggings()).getHandle()));
-            if(player.getInventory().getBoots() != null)  otherGuyC.getHandle().netServerHandler.sendPacket(new Packet5EntityEquipment(id, 4, ((CraftItemStack)player.getInventory().getBoots()).getHandle()));
+            if(player.getInventory().getHelmet() != null) otherGuyC.getHandle().netServerHandler.sendPacket(new Packet5EntityEquipment(id, 4, ((CraftItemStack)player.getInventory().getHelmet()).getHandle()));
+            if(player.getInventory().getChestplate() != null) otherGuyC.getHandle().netServerHandler.sendPacket(new Packet5EntityEquipment(id, 3, ((CraftItemStack)player.getInventory().getChestplate()).getHandle()));
+            if(player.getInventory().getLeggings() != null) otherGuyC.getHandle().netServerHandler.sendPacket(new Packet5EntityEquipment(id, 2, ((CraftItemStack)player.getInventory().getLeggings()).getHandle()));
+            if(player.getInventory().getBoots() != null)  otherGuyC.getHandle().netServerHandler.sendPacket(new Packet5EntityEquipment(id, 1, ((CraftItemStack)player.getInventory().getBoots()).getHandle()));
         }
     }
 

--- a/src/main/java/org/kitteh/tag/TagAPI.java
+++ b/src/main/java/org/kitteh/tag/TagAPI.java
@@ -22,6 +22,7 @@ import java.util.logging.Level;
 import net.minecraft.server.*;
 
 import org.bukkit.craftbukkit.entity.CraftPlayer;
+import org.bukkit.craftbukkit.inventory.CraftItemStack;
 import org.bukkit.entity.Player;
 import org.bukkit.event.EventHandler;
 import org.bukkit.event.EventPriority;
@@ -134,6 +135,11 @@ public class TagAPI extends JavaPlugin {
             final CraftPlayer otherGuyC = (CraftPlayer) forWhom;
             otherGuyC.getHandle().netServerHandler.sendPacket(new Packet29DestroyEntity(id));
             otherGuyC.getHandle().netServerHandler.sendPacket(new Packet20NamedEntitySpawn(human));
+            otherGuyC.getHandle().netServerHandler.sendPacket(new Packet5EntityEquipment(id, 0, ((CraftItemStack)player.getItemInHand()).getHandle()));
+            otherGuyC.getHandle().netServerHandler.sendPacket(new Packet5EntityEquipment(id, 1, ((CraftItemStack)player.getInventory().getHelmet()).getHandle()));
+            otherGuyC.getHandle().netServerHandler.sendPacket(new Packet5EntityEquipment(id, 2, ((CraftItemStack)player.getInventory().getChestplate()).getHandle()));
+            otherGuyC.getHandle().netServerHandler.sendPacket(new Packet5EntityEquipment(id, 3, ((CraftItemStack)player.getInventory().getLeggings()).getHandle()));
+            otherGuyC.getHandle().netServerHandler.sendPacket(new Packet5EntityEquipment(id, 4, ((CraftItemStack)player.getInventory().getBoots()).getHandle()));
         }
     }
 

--- a/src/main/java/org/kitteh/tag/TagAPI.java
+++ b/src/main/java/org/kitteh/tag/TagAPI.java
@@ -135,11 +135,11 @@ public class TagAPI extends JavaPlugin {
             final CraftPlayer otherGuyC = (CraftPlayer) forWhom;
             otherGuyC.getHandle().netServerHandler.sendPacket(new Packet29DestroyEntity(id));
             otherGuyC.getHandle().netServerHandler.sendPacket(new Packet20NamedEntitySpawn(human));
-            otherGuyC.getHandle().netServerHandler.sendPacket(new Packet5EntityEquipment(id, 0, ((CraftItemStack)player.getItemInHand()).getHandle()));
-            otherGuyC.getHandle().netServerHandler.sendPacket(new Packet5EntityEquipment(id, 1, ((CraftItemStack)player.getInventory().getHelmet()).getHandle()));
-            otherGuyC.getHandle().netServerHandler.sendPacket(new Packet5EntityEquipment(id, 2, ((CraftItemStack)player.getInventory().getChestplate()).getHandle()));
-            otherGuyC.getHandle().netServerHandler.sendPacket(new Packet5EntityEquipment(id, 3, ((CraftItemStack)player.getInventory().getLeggings()).getHandle()));
-            otherGuyC.getHandle().netServerHandler.sendPacket(new Packet5EntityEquipment(id, 4, ((CraftItemStack)player.getInventory().getBoots()).getHandle()));
+            if(player.getItemInHand() != null) otherGuyC.getHandle().netServerHandler.sendPacket(new Packet5EntityEquipment(id, 0, ((CraftItemStack)player.getItemInHand()).getHandle()));
+            if(player.getInventory().getHelmet() != null) otherGuyC.getHandle().netServerHandler.sendPacket(new Packet5EntityEquipment(id, 1, ((CraftItemStack)player.getInventory().getHelmet()).getHandle()));
+            if(player.getInventory().getChestplate() != null) otherGuyC.getHandle().netServerHandler.sendPacket(new Packet5EntityEquipment(id, 2, ((CraftItemStack)player.getInventory().getChestplate()).getHandle()));
+            if(player.getInventory().getLeggings() != null) otherGuyC.getHandle().netServerHandler.sendPacket(new Packet5EntityEquipment(id, 3, ((CraftItemStack)player.getInventory().getLeggings()).getHandle()));
+            if(player.getInventory().getBoots() != null)  otherGuyC.getHandle().netServerHandler.sendPacket(new Packet5EntityEquipment(id, 4, ((CraftItemStack)player.getInventory().getBoots()).getHandle()));
         }
     }
 


### PR DESCRIPTION
Armor (and sometimes held items, it seems) will disappear when a player is refreshed, because Packet 5 isn't resent.  This resends the relevant packets on refresh.
