### PR TITLE
Fixed the authors nag bs

### DIFF
--- a/src/main/resources/plugin.yml
+++ b/src/main/resources/plugin.yml
@@ -1,6 +1,6 @@
 name: TagAPI
 main: org.kitteh.tag.TagAPI
-author: mbaxter
+authors: [mbaxter]
 description: Name tag API
 version: '${project.version}'
 softdepend: [ProtocolLib]


### PR DESCRIPTION
[18:06] <Tag_118> Has anyone had problems with tagapi making this error occur "Nag author: 'mbaxter' of 'TagAPI' about the following: This plugin is not properly shutting down its async tasks when it is being reloaded.  This may cause conflicts with the newly loaded version of the plugin"
